### PR TITLE
Add Creek's JSON Schema Validation comparison site

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ This suite is being used by:
 
 ### Java
 
+* [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/functional) (Comparison site for JVM-based validator implementations)
 * [json-schema-validator](https://github.com/daveclayton/json-schema-validator)
 * [everit-org/json-schema](https://github.com/everit-org/json-schema)
 * [networknt/json-schema-validator](https://github.com/networknt/json-schema-validator)
@@ -278,6 +279,10 @@ This suite is being used by:
 * [jsen](https://github.com/bugventure/jsen)
 * [ajv](https://github.com/epoberezkin/ajv)
 * [djv](https://github.com/korzio/djv)
+
+### Kotlin
+
+* [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/functional) (Comparison site for JVM-based validator implementations)
 
 ### Node.js
 
@@ -327,6 +332,7 @@ Node-specific support is maintained in a [separate repository](https://github.co
 
 ### Scala
 
+* [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/functional) (Comparison site for JVM-based validator implementations)
 * [typed-json](https://github.com/frawa/typed-json)
 
 ### Swift


### PR DESCRIPTION
The site linked to is a data-driven functional and performance benchmark of JVM based validator implementations.

Micro-site: https://www.creekservice.org/json-schema-validation-comparison/
Repo: https://github.com/creek-service/json-schema-validation-comparison

It would be great if we can link to the results from this page.